### PR TITLE
Resolves https://github.com/Islandora-CLAW/CLAW/issues/437

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ubuntu-xenial-16.04-cloudimg-console.log
 downloads
+.vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ubuntu-xenial-16.04-cloudimg-console.log
+downloads

--- a/README.md
+++ b/README.md
@@ -76,12 +76,15 @@ Tomcat Manager:
   * username: islandora
   * password: islandora
 
-You can connect to the machine via ssh: `ssh -p 2222 vagrant@localhost`
+You can connect to the machine via ssh:
+
+  * `vagrant ssh`
+  * `ssh -p 2222 ubuntu@localhost`
 
 The default VM login details are:
   
-  * username: vagrant
-  * password: vagrant
+  * username: ubuntu
+  * password: ubuntu
 
 ## Environment
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -10,7 +10,10 @@ if [ ! -d "$DOWNLOAD_DIR" ]; then
   mkdir -p "$DOWNLOAD_DIR"
 fi
 
+#######################################################################
+# Work around for https://bugs.launchpad.net/cloud-images/+bug/1569237
 echo "ubuntu:ubuntu" | chpasswd
+#######################################################################
 
 cd "$HOME_DIR"
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -10,6 +10,8 @@ if [ ! -d "$DOWNLOAD_DIR" ]; then
   mkdir -p "$DOWNLOAD_DIR"
 fi
 
+echo "ubuntu:ubuntu" | chpasswd
+
 cd "$HOME_DIR"
 
 # Set apt-get for non-interactive mode


### PR DESCRIPTION
* Updates README with correct information
* Sets password for ubuntu user in bootstrap.sh due to https://bugs.launchpad.net/cloud-images/+bug/1569237
* Adds a .gitignore, which we forgot to do when we split out into a single repo.
* See: https://github.com/Islandora-CLAW/CLAW/issues/437

# How to test:
  * `git clone https://github.com/Islandora-CLAW/claw_vagrant`
  * `cd claw_vagrant`
  * `git checkout issue-437`
  * `vagrant box update`
  * `vagrant up`
  * verify you can `ssh -p 2222 ubuntu@localhost` with `ubuntu` as the password.

You may get an error like this:
```
[nruest@gorila:claw_vagrant] (git)-[issue-437]-$ ssh -p 2222 ubuntu@localhost
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
Someone could be eavesdropping on you right now (man-in-the-middle attack)!
It is also possible that a host key has just been changed.
The fingerprint for the ECDSA key sent by the remote host is
SHA256:fMkXc8Hkh/VrvoI1QICeQbvM8g/a6+P4DIl8dzyCxbw.
Please contact your system administrator.
Add correct host key in /home/nruest/.ssh/known_hosts to get rid of this message.
Offending ECDSA key in /home/nruest/.ssh/known_hosts:60
  remove with:
  ssh-keygen -f "/home/nruest/.ssh/known_hosts" -R [localhost]:2222
ECDSA host key for [localhost]:2222 has changed and you have requested strict checking.
Host key verification failed.
```

That means you just need to edit your `~./.ssh/known_hosts` file. It'll tell you which line you should remove. In the example above, it is line 60.

@kimpham54 @Natkeeran @edf are you available to test?