### PR TITLE
Removes installation of webprofiler from drupal.sh

### DIFF
--- a/scripts/drupal.sh
+++ b/scripts/drupal.sh
@@ -77,9 +77,6 @@ $DRUSH_CMD en -y media_entity_image
 # Devel
 $DRUSH_CMD -y en devel
 
-# Web Profiler
-$DRUSH_CMD en -y webprofiler
-
 # Apache Solr
 ## https://www.drupal.org/node/2613470
 $DRUSH_CMD -y pm-uninstall search


### PR DESCRIPTION
See: [Islandora-CLAW/CLAW#434](https://github.com/Islandora-CLAW/CLAW/issues/434)

Simply removes lines 79-81 of scripts/drupal.sh.