### PR TITLE
Triplestore inferencing

### DIFF
--- a/configs/blazegraph.properties
+++ b/configs/blazegraph.properties
@@ -1,0 +1,13 @@
+com.bigdata.rdf.store.AbstractTripleStore.textIndex=false                                                                                         
+com.bigdata.rdf.store.AbstractTripleStore.axiomsClass=com.bigdata.rdf.axioms.OwlAxioms
+com.bigdata.rdf.sail.isolatableIndices=false
+com.bigdata.rdf.store.AbstractTripleStore.justify=true
+com.bigdata.rdf.sail.truthMaintenance=true
+com.bigdata.rdf.sail.namespace=islandora
+com.bigdata.rdf.store.AbstractTripleStore.quads=false
+com.bigdata.namespace.islandora.lex.com.bigdata.btree.BTree.branchingFactor=400
+com.bigdata.journal.Journal.groupCommit=false
+com.bigdata.namespace.islandora.spo.com.bigdata.btree.BTree.branchingFactor=1024
+com.bigdata.rdf.store.AbstractTripleStore.geoSpatial=false
+com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers=false
+

--- a/configs/inference.nt
+++ b/configs/inference.nt
@@ -1,0 +1,1 @@
+<http://pcdm.org/models#memberOf> <http://www.w3.org/2002/07/owl#inverseOf> <http://pcdm.org/models#hasMember> .

--- a/scripts/blazegraph.sh
+++ b/scripts/blazegraph.sh
@@ -29,3 +29,8 @@ sleep 15
 sed -i 's|log4j.appender.ruleLog.File=rules.log|log4j.appender.ruleLog.File=/var/log/tomcat7/rules.log|g' /var/lib/tomcat7/webapps/bigdata/WEB-INF/classes/log4j.properties
 sed -i 's|com.bigdata.journal.AbstractJournal.file=blazegraph.jnl|com.bigdata.journal.AbstractJournal.file=/opt/blazegraph/blazegraph.jnl|g' /var/lib/tomcat7/webapps/bigdata/WEB-INF/RWStore.properties
 service tomcat7 restart
+
+cd "$HOME_DIR"/islandora/configs
+echo "Creating namespace with inferencing"
+curl -v -X POST -H 'Content-Type:text/plain' --data-binary @blazegraph.properties http://localhost:8080/bigdata/namespace
+curl -v -X POST -H 'Content-Type:text/plain' --data-binary @inference.nt http://localhost:8080/bigdata/namespace/islandora/sparql

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -14,7 +14,7 @@ fi
 
 if [ -f "$KARAF_DIR/etc/org.fcrepo.camel.indexing.triplestore.cfg" ]; then
   # Update fcrepo triplestore indexing config
-  sed -i 's|triplestore.baseUrl=http://localhost:8080/fuseki/test/update|triplestore.baseUrl=http://localhost:8080/bigdata/sparql|' "$KARAF_DIR/etc/org.fcrepo.camel.indexing.triplestore.cfg"
+  sed -i 's|triplestore.baseUrl=http://localhost:8080/fuseki/test/update|triplestore.baseUrl=http://localhost:8080/bigdata/namespace/islandora/sparql|' "$KARAF_DIR/etc/org.fcrepo.camel.indexing.triplestore.cfg"
   sed -i 's|input.stream=broker:topic:fedora|input.stream=activemq:queue:fcrepo-indexing-triplestore|' "$KARAF_DIR/etc/org.fcrepo.camel.indexing.triplestore.cfg"
   sed -i 's|triplestore.reindex.stream=broker:queue:triplestore.reindex|triplestore.reindex.stream=activemq:queue:triplestore.reindex|' "$KARAF_DIR/etc/org.fcrepo.camel.indexing.triplestore.cfg"
 else

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -55,6 +55,7 @@ fi
 if [ -f "$KARAF_DIR/etc/ca.islandora.alpaca.indexing.triplestore.cfg" ]; then
   # Update islandora triplestore indexer config
   sed -i 's|input.stream=broker:queue:islandora-indexing-triplestore|input.stream=activemq:queue:islandora-indexing-triplestore|' "$KARAF_DIR/etc/ca.islandora.alpaca.indexing.triplestore.cfg"
+  sed -i 's|triplestore.baseUrl=http://localhost:8080/bigdata/namespace/kb/sparql|triplestore.baseUrl=http://localhost:8080/bigdata/namespace/islandora/sparql|' "$KARAF_DIR/etc/ca.islandora.alpaca.indexing.triplestore.cfg"
   sed -i 's|drupal.username=|drupal.username=admin|' "$KARAF_DIR/etc/ca.islandora.alpaca.indexing.triplestore.cfg"
   sed -i 's|drupal.password=|drupal.password=islandora|' "$KARAF_DIR/etc/ca.islandora.alpaca.indexing.triplestore.cfg"
 else


### PR DESCRIPTION
Resolves Islandora-CLAW/CLAW#535

### To Test
* Pull in the changes from this PR
* `vagrant up`
* In the install, it loads an inferencing triple for `pcdm:memberOf`, so to test, make two collections, one belonging to the other.  First, I had to update my display and form display for Collections.
![screenshot from 2017-02-10 22-48-10](https://cloud.githubusercontent.com/assets/20773151/22850869/93401420-efe8-11e6-9b0d-67af652c143d.png)
![screenshot from 2017-02-10 22-53-59](https://cloud.githubusercontent.com/assets/20773151/22850873/9bccd8f8-efe8-11e6-8e02-efce2c47b4ec.png)
* Then make the two collections, setting the memberOf field in the second to point to the first.
![screenshot from 2017-02-10 22-52-35](https://cloud.githubusercontent.com/assets/20773151/22850883/c1549afc-efe8-11e6-8a35-d3ca71dc2664.png)
![screenshot from 2017-02-10 22-55-27](https://cloud.githubusercontent.com/assets/20773151/22850884/c6278080-efe8-11e6-8fca-30da5aff61e5.png)
* Check out the triplestore and issue a query for the first collection.  It should have the `pcdm:hasMember` triple inferred automatically.
![screenshot from 2017-02-10 22-57-20](https://cloud.githubusercontent.com/assets/20773151/22850890/128536e8-efe9-11e6-9263-a48ca7bb72f4.png)