### PR TITLE
Add Syn config to Vagrant.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,6 +64,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, :path => "./scripts/drupal.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/fcrepo.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/blazegraph.sh", :args => home_dir
+  config.vm.provision :shell, :path => "./scripts/syn.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/karaf.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/alpaca.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/islandora-karaf-components.sh", :args => home_dir

--- a/configs/Syn/syn-settings.xml
+++ b/configs/Syn/syn-settings.xml
@@ -1,0 +1,3 @@
+<sites version='1'>
+        <site algorithm='RS256' encoding='PEM' path='/home/ubuntu/auth/public.key' default='true'/>
+</sites>

--- a/configs/Syn/web.xml
+++ b/configs/Syn/web.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+	version="3.0">
+
+	<display-name>Fedora 4</display-name>
+
+	<context-param>
+		<param-name>contextConfigLocation</param-name>
+		<param-value>WEB-INF/classes/spring/master.xml</param-value>
+	</context-param>
+
+	<listener>
+		<listener-class>org.fcrepo.http.commons.FedoraContextLoaderListener</listener-class>
+	</listener>
+
+  <servlet>
+    <servlet-name>jersey-servlet</servlet-name>
+    <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
+
+    <init-param>
+      <param-name>javax.ws.rs.Application</param-name>
+      <param-value>org.fcrepo.http.commons.FedoraApplication</param-value>
+    </init-param>
+
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+
+  <servlet-mapping>
+		<servlet-name>jersey-servlet</servlet-name>
+		<url-pattern>/rest/*</url-pattern>
+
+	</servlet-mapping>
+
+  <filter>
+    <filter-name>ETagFilter</filter-name>
+    <filter-class>org.springframework.web.filter.ShallowEtagHeaderFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>ETagFilter</filter-name>
+    <url-pattern>/static/*</url-pattern>
+  </filter-mapping>
+
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>Fedora4</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+        <role-name>*</role-name>
+    </auth-constraint>
+    <user-data-constraint>
+      <transport-guarantee>NONE</transport-guarantee>
+    </user-data-constraint>
+  </security-constraint>
+  <security-role>
+    <role-name>islandora</role-name>
+  </security-role>
+  <login-config>
+    <auth-method>BASIC</auth-method>
+    <realm-name>fcrepo</realm-name>
+  </login-config>
+
+</web-app>

--- a/scripts/syn.sh
+++ b/scripts/syn.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Syn
+echo "Building Syn"
+
+HOME_DIR=$1
+
+if [ -f "$HOME_DIR/islandora/configs/variables" ]; then
+  . "$HOME_DIR"/islandora/configs/variables
+fi
+
+cd "$HOME_DIR"
+git clone https://github.com/jonathangreen/Syn.git
+cd Syn
+chown -R ubuntu:ubuntu "$HOME_DIR/Syn"
+sudo -u ubuntu ./gradlew build
+
+cp build/libs/islandora-syn-*-all.jar /var/lib/tomcat8/lib/
+sed -i 's|</Context>|    <Valve className="ca.islandora.syn.valve.SynValve"/>\n</Context>|g' /var/lib/tomcat8/conf/context.xml
+cp "$HOME_DIR/islandora/configs/Syn/web.xml" /var/lib/tomcat8/webapps/fcrepo/WEB-INF/web.xml
+cp "$HOME_DIR/islandora/configs/Syn/syn-settings.xml" /var/lib/tomcat8/conf/syn-settings.xml
+
+service tomcat8 restart


### PR DESCRIPTION
Adds configuration to vagrant to compile and setup Syn to do JWT authentication on the Fedora side. This will need to have the git repo updated once the java code lives somewhere other then my own GitHub.

Part of:
Islandora-CLAW/CLAW#520