### PR TITLE
Add phpcs & setup Drupal sniff file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,7 +60,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, :path => "./scripts/lamp-server.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/fits.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/solr.sh", :args => home_dir
-  config.vm.provision :shell, :path => "./scripts/composer.sh", :args => home_dir
+  config.vm.provision :shell, :path => "./scripts/composer.sh", :args => home_dir, :privileged =>false
   config.vm.provision :shell, :path => "./scripts/drupal.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/fcrepo.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/blazegraph.sh", :args => home_dir

--- a/scripts/composer.sh
+++ b/scripts/composer.sh
@@ -4,3 +4,11 @@ echo "Installing Composer"
 curl -sS https://getcomposer.org/installer | php
 php composer.phar install --no-progress
 mv composer.phar /usr/local/bin/composer
+
+echo "Installing phpcs"
+cd $HOME
+composer global require drupal/coder
+composer global update drupal/coder --prefer-source
+export PATH="$PATH:$HOME/.config/composer/vendor/bin"
+echo 'export PATH="$PATH:$HOME/.config/composer/vendor/bin"' >> .bashrc
+phpcs --config-set installed_paths $HOME/.config/composer/vendor/drupal/coder/coder_sniffer

--- a/scripts/composer.sh
+++ b/scripts/composer.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 echo "Installing Composer"
 
+HOME_DIR=$1
+
+if [ -f "$HOME_DIR/islandora/configs/variables" ]; then
+  . "$HOME_DIR"/islandora/configs/variables
+fi
+
 curl -sS https://getcomposer.org/installer | php
 php composer.phar install --no-progress
 mv composer.phar /usr/local/bin/composer
 
-echo "Installing phpcs"
+echo "Installing phpcs" 
 cd $HOME
 composer global require drupal/coder
 composer global update drupal/coder --prefer-source

--- a/scripts/composer.sh
+++ b/scripts/composer.sh
@@ -7,9 +7,10 @@ if [ -f "$HOME_DIR/islandora/configs/variables" ]; then
   . "$HOME_DIR"/islandora/configs/variables
 fi
 
+cd /tmp
 curl -sS https://getcomposer.org/installer | php
 php composer.phar install --no-progress
-mv composer.phar /usr/local/bin/composer
+sudo mv composer.phar /usr/local/bin/composer
 
 echo "Installing phpcs" 
 cd $HOME

--- a/scripts/fits.sh
+++ b/scripts/fits.sh
@@ -17,7 +17,7 @@ if [ ! -f "$DOWNLOAD_DIR/fits-$FITS_WS_VERSION.war" ]; then
   wget -q -O "$DOWNLOAD_DIR/fits-$FITS_WS_VERSION.war" "http://projects.iq.harvard.edu/files/fits/files/fits-$FITS_WS_VERSION.war"
 fi
 
-unzip "$DOWNLOAD_DIR/fits-$FITS_VERSION.zip" -d /opt
+unzip -q "$DOWNLOAD_DIR/fits-$FITS_VERSION.zip" -d /opt
 mv /opt/fits-$FITS_VERSION /opt/fits
 chown tomcat8:tomcat8 /opt/fits
 


### PR DESCRIPTION
**GitHub Issue**: Resolves https://github.com/Islandora-CLAW/CLAW/issues/563

# What does this Pull Request do?

Adds `phpcs` & sets up the Drupal coding standards sniff file.

@Islandora-CLAW/committers let me know if it is fine in the composer file, or if you'd like it in it's own file.

# What's new?
See above.

# How should this be tested?

* clone fork
* `vagrant up`
* verify `phpcs` is available on the user's path
* `phpcs --standard=Drupal --ignore=*.md --extensions=php,module,inc,install,test,profile,theme,css,info path/to/islandora`

# Interested parties
Tag (@Islandora-CLAW/committers