### PR TITLE
Add imagemagick with JP2 support to bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -63,6 +63,14 @@ for MAN_FILE in $MAN_FILES; do gzip /usr/share/man/man1/"${MAN_FILE##*/}"; done
 # More helpful packages
 apt-get -y -qq install htop tree zsh fish unzip
 
+# Install imagemagick with jp2 support. 
+# JP2 isn't included in Ubuntu imagemagick as per this launchpad ticket:
+# https://bugs.launchpad.net/ubuntu/+source/openjpeg2/+bug/711061
+# Looks like there is some effort to bring it in eventually.
+apt-add-repository -yu ppa:lyrasis/imagemagick-jp2
+apt-get -f install -y --allow-downgrades imagemagick=8:6.8.9.9-7ubuntu5.3ppa1 imagemagick-6.q16=8:6.8.9.9-7ubuntu5.3ppa1 imagemagick-common=8:6.8.9.9-7ubuntu5.3ppa1 libmagickcore-6.q16-2=8:6.8.9.9-7ubuntu5.3ppa1 libmagickcore-6.q16-2-extra=8:6.8.9.9-7ubuntu5.3ppa1 libmagickwand-6.q16-2=8:6.8.9.9-7ubuntu5.3ppa1
+apt-mark hold imagemagick imagemagick-6.q16 imagemagick-common libmagickcore-6.q16-2 libmagickcore-6.q16-2-extra libmagickwand-6.q16-2 
+
 # Set some params so it's non-interactive for the lamp-server install
 debconf-set-selections <<< 'mysql-server mysql-server/root_password password islandora'
 debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password islandora'


### PR DESCRIPTION
## GitHub Issue

Part of:
Islandora-CLAW/CLAW#572

## What does this Pull Request do?

Add imagemagick with JP2 support to bootstrap.sh. This is installed from  a PPA that LYRASIS (me) maintains, for imagemagick with JP2 support.

## How should this be tested?

* vagrant up
* convert image.jp2 image.png
* make sure image.png looks okay