### PR TITLE
Enable Xdebug

### DIFF
--- a/scripts/drupal.sh
+++ b/scripts/drupal.sh
@@ -11,8 +11,25 @@ fi
 cd "$HOME_DIR"
 
 # Drush and drupal deps
-apt-get -y -qq install php7.0-gd php7.0-xml php7.0-mysql php7.0-curl php7.0-json
+apt-get -y -qq install php7.0-gd php7.0-xml php7.0-mysql php7.0-curl php7.0-json php-xdebug
 a2enmod rewrite
+
+# Setup Xdebug
+XDEBUG=$(cat <<EOF
+zend_extension=xdebug.so
+xdebug.idekey="debugit"
+xdebug.remote_host=10.0.2.2
+# Disabling the previous line and enabling the following will allow any remote to connect
+# xdebug.remote_connect_back = 1
+xdebug.remote_connect_back=1
+xdebug.remote_enable=1
+xdebug.remote_autostart=0
+xdebug.remote_handler="dbgp"
+EOF
+)
+
+echo "${XDEBUG}"> /etc/php/7.0/mods-available/xdebug.ini
+
 service apache2 reload
 cd /var/www/html
 


### PR DESCRIPTION

Resolves islandora-claw/claw#575

# What does this Pull Request do?

As basic as it gets. Enables Xdebug on Vagrant as described by @whikloj in https://github.com/Islandora-CLAW/CLAW/wiki/Setting-up-CLAW-Vagrant-w-Xdebug

# What's new?
Please read https://github.com/Islandora-CLAW/CLAW/wiki/Setting-up-CLAW-Vagrant-w-Xdebug to make good use of this

# How should this be tested?

Did i mention https://github.com/Islandora-CLAW/CLAW/wiki/Setting-up-CLAW-Vagrant-w-Xdebug?

# Additional Notes:
Since the host (your computer's) IP can vary when using Vagrant, I added a, commented out, option that makes Xdebug slower but independent of that IP. Since it is commented out it does not get slower by default of course

Enabled by default
```Shell
xdebug.remote_host=10.0.2.2
````

Disabled by default
```Shell
# Disabling the previous line and enabling the following will allow any remote to connect
# xdebug.remote_connect_back = 1
````

# Interested parties
@Islandora-CLAW/committers