### PR TITLE
update FITS, address Islandora-CLAW/CLAW#584

### DIFF
--- a/configs/variables
+++ b/configs/variables
@@ -12,7 +12,7 @@ BLAZEGRAPH_VERSION=2.1.4
 DRUPAL_HOME="/var/www/html/drupal"
 DRUSH_CMD="$DRUPAL_HOME/vendor/drush/drush/drush -r $DRUPAL_HOME/web"
 DRUPAL_CMD="$DRUPAL_HOME/vendor/drupal/console/bin/drupal --root=$DRUPAL_HOME/web"
-FITS_VERSION=1.0.5
+FITS_VERSION=1.0.7
 FITS_WS_VERSION=1.1.3
 MYSQL_USER=root
 MYSQL_PASS=islandora


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/584

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?

Update FITS from 1.0.5 to 1.0.7

# What's new?

update of the number '5' to the number '7'

# How should this be tested?

1. checkout this PR, run vagrant up
2. check in ~/islandora/downloads that fits-1.0.7.zip is in the directory.
3. check in opt/fits/version.properties that the version number says '1.0.7'

# Additional Notes:

# Interested parties
@ruebot 