### PR TITLE
Adding fcrepo indexing and an extra inference triple for fileOf

### DIFF
--- a/configs/inference.nt
+++ b/configs/inference.nt
@@ -1,1 +1,2 @@
 <http://pcdm.org/models#memberOf> <http://www.w3.org/2002/07/owl#inverseOf> <http://pcdm.org/models#hasMember> .
+<http://pcdm.org/models#fileOf> <http://www.w3.org/2002/07/owl#inverseOf> <http://pcdm.org/models#hasFile> .

--- a/configs/karaf/alpaca.script
+++ b/configs/karaf/alpaca.script
@@ -6,5 +6,6 @@ feature:install fcrepo-service-camel
 
 feature:install islandora-connector-broadcast
 feature:install islandora-indexing-triplestore
+feature:install islandora-indexing-fcrepo
 
 feature:install fcrepo-indexing-triplestore


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW#618

# What does this Pull Request do?

Adds fcrepo indexing to the vagrant install, and adds an inferencing triple for pcdm:fileOf.

# How should this be tested?

To be tested with the rest of Islandora-CLAW/CLAW#618

# Interested parties
@Islandora-CLAW/committers