### PR TITLE
504: Adding API-X to claw_vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 ubuntu-xenial-16.04-cloudimg-console.log
 downloads
 .vagrant
+/build/
+.classpath
+.project
+.settings/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 5432, host: 5432 # PostgreSQL
   #config.vm.network :forwarded_port, guest: 8383, host: 8383 # Loris
   config.vm.network :forwarded_port, guest: 8983, host: 8983 # Solr
-
+  config.vm.network :forwarded_port, guest: 8081, host: 8081 # API-X
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--memory", $memory]
     vb.customize ["modifyvm", :id, "--cpus", $cpus]

--- a/configs/karaf/alpaca.script
+++ b/configs/karaf/alpaca.script
@@ -1,3 +1,5 @@
+config:property-set -p org.fcrepo.apix.registry.http timeout.socket.ms 1000
+
 feature:repo-add file:/home/ubuntu/Alpaca/karaf/build/resources/main/features.xml
 feature:repo-add mvn:org.fcrepo.apix/fcrepo-api-x-karaf/0.2.0/xml/features
 

--- a/configs/karaf/alpaca.script
+++ b/configs/karaf/alpaca.script
@@ -1,5 +1,5 @@
 feature:repo-add file:/home/ubuntu/Alpaca/karaf/build/resources/main/features.xml
-feature:repo-add mvn:org.fcrepo.apix/fcrepo-api-x-karaf/0.1.0/xml/features
+feature:repo-add mvn:org.fcrepo.apix/fcrepo-api-x-karaf/0.2.0/xml/features
 
 feature:install fcrepo-service-activemq
 feature:install fcrepo-service-camel
@@ -9,5 +9,6 @@ feature:install islandora-indexing-triplestore
 feature:install islandora-indexing-fcrepo
 
 feature:install islandora-http-client
+feature:install fcrepo-api-x
 
 feature:install fcrepo-indexing-triplestore

--- a/configs/karaf/alpaca.script
+++ b/configs/karaf/alpaca.script
@@ -8,4 +8,6 @@ feature:install islandora-connector-broadcast
 feature:install islandora-indexing-triplestore
 feature:install islandora-indexing-fcrepo
 
+feature:install islandora-http-client
+
 feature:install fcrepo-indexing-triplestore


### PR DESCRIPTION
**Add API-X to vagrant install**: (https://github.com/Islandora-CLAW/CLAW/issues/504)

* https://github.com/fcrepo4-labs/fcrepo-api-x/pull/113
* https://github.com/Islandora-CLAW/Alpaca/pull/40

# What does this Pull Request do?

Opens a port for API-X and adds a Syn-aware HTTP client feature supplied from the Alpaca PR linked above.

After this PR and the ones above are merged and API-X has cut a release, API-X should come up in `claw_vagrant` out-of-the-box.

# How should this be tested?

Once all merges and releases have been accomplished, API-X should appear after the first `vagrant up` and should be available at mapped port 8081.

# Interested parties
@ruebot @dhlamb @birkland