### PR TITLE
mirador.sh install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,5 +58,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, :path => "./scripts/config.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/crayfish.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/post-install.sh", :args => home_dir
-
+  #config.vm.provision :shell, :path => "./scripts/mirador.sh", :args => home_dir
+  
 end

--- a/scripts/mirador.sh
+++ b/scripts/mirador.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+echo "Installing Mirador"
+
+#HOME_DIR=$1
+#if [ -f "$HOME_DIR/islandora/configs/variables" ]; then
+#  . "$HOME_DIR"/islandora/configs/variables
+#fi
+#cd "$HOME_DIR"
+
+cd /tmp && { curl -LOk https://github.com/NVLI/mirador-js/archive/master.zip; curl -LOk https://ftp.drupal.org/files/projects/mirador-8.x-1.x-dev.zip ; cd -;}
+
+cd /var/www/html/drupal/web/libraries && { unzip /tmp/master.zip -d . ;}
+
+rm /tmp/master.zip
+
+cd /var/www/html/drupal/web/modules/contrib/ && { unzip /tmp/mirador-8.x-1.x-dev.zip -d . ;} 
+
+rm /tmp/mirador-8.x-1.x-dev.zip
+
+echo 'for unknown reasons I cannot get permissions to allow this drush en to be scripted...'
+
+echo 'you'll have to vagrant ssh, cd to /var/www/html/drupal, then execute the following drush (or I suppose you could gui enable):'
+
+echo 'drush en mirador -y'
+
+#"$DRUSH_CMD" en mirador -y
+
+#drush pm-uninstall


### PR DESCRIPTION
**GitHub Issue**: (https://github.com/Islandora-CLAW/CLAW/issues/645)

# What does this Pull Request do?

Downloads and installs mirador drupal module, and library dependencies

# What's new?
would give users an option to install mirador with a `vagrant provision`

* Added scripts/mirador.sh
*you must add a line; to your Vagrantfile to enable this script 

* Could this change impact execution of existing code?
Gads I hope not...

# How should this be tested?

* To Test that the Pull Request does what is intended.
add:
`config.vm.provision :shell, :path => "./scripts/mirador.sh", :args => home_dir` 
to the pre-penultimate (3rd to last) line of Vagrantfile

# Additional Notes:
You must enable the module yourself. bc I couldn't figure out permissions.. 👎 

# Interested parties
@Islandora-CLAW/committers @whikloj 