### PR TITLE
Add switch to let Tomcat allow encoded slashes

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -50,6 +50,7 @@ chown -R tomcat8:tomcat8 /var/lib/tomcat8
 chown -R tomcat8:tomcat8 /var/log/tomcat8
 chmod -R g+w /var/lib/tomcat8
 chmod -R g+w /var/log/tomcat8
+sed -i '$iJAVA_OPTS="${JAVA_OPTS} -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"' /etc/defaults/tomcat8
 
 # Wget and curl
 apt-get -y -qq install wget curl


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

Adds Java option so Tomcat will allow urlencoded slashes. See [here](https://github.com/Islandora/islandora_openseadragon/pull/65#issuecomment-302468998) related to using Cantaloupe for Islandora 1.x

I keep getting stung by this, so I figured we should get it into the build process now.

# What's new?
Adds a JAVA_OPT

# How should this be tested?

**Without this PR** try going to http://localhost:8080/cantaloupe/iiif/2/2017-05%2FLouis_Riel.jp2/info.json
You should get a white screen.

**With this PR** try going to the same URL.
You should get a 404 error displayed to the screen, somewhat like.
```
404 Not Found
Failed to resolve 2017-05/Louis_Riel.jp2 to /opt/cantaloupe/images/2017-05/Louis_Riel.jp2
```

# Interested parties
@Islandora-CLAW/committers