### PR TITLE
Updates claw_vagrant to use FITS 1.1.1.

### DIFF
--- a/configs/variables
+++ b/configs/variables
@@ -12,7 +12,7 @@ BLAZEGRAPH_VERSION=2.1.4
 DRUPAL_HOME="/var/www/html/drupal"
 DRUSH_CMD="$DRUPAL_HOME/vendor/drush/drush/drush -r $DRUPAL_HOME/web"
 DRUPAL_CMD="$DRUPAL_HOME/vendor/drupal/console/bin/drupal --root=$DRUPAL_HOME/web"
-FITS_VERSION=1.0.7
+FITS_VERSION=1.1.1
 FITS_WS_VERSION=1.1.3
 MYSQL_USER=root
 MYSQL_PASS=islandora


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/659

# What does this Pull Request do?

Updates the claw_vagrant `configs/variables` file to use FITS 1.1.1.

# What's new?

Newly provisioned CLAW Vagrants will have FITS 1.1.1 installed rather than FITS 1.0.7.

# How should this be tested?
* Create a new CLAW vagrant VM.
* Once provisioned, navigate to http://localhost:8080/fits/ and confirm that you see "FITS Version: 1.1.1" under the FITS Web Service banner.

# Interested parties
@Islandora-CLAW/committers