### PR TITLE
Downloads and enables carapace theme and deps

### DIFF
--- a/scripts/drupal.sh
+++ b/scripts/drupal.sh
@@ -88,7 +88,7 @@ composer require "drupal/adaptivetheme:^2.0" "drupal/at_tools:^2.0" "drupal/layo
 $DRUSH_CMD en -y at_tools
 $DRUSH_CMD en -y layout_plugin
 mkdir /var/www/html/drupal/web/themes/custom
-git clone https://github.com/Favenzio/carapace /var/www/html/drupal/web/themes/custom/carapace
+git clone https://github.com/Islandora-CLAW/carapace /var/www/html/drupal/web/themes/custom/carapace
 chown -R www-data:www-data /var/www/html/drupal/web/themes/custom/carapace
 $DRUSH_CMD en -y carapace
 $DRUSH_CMD -y config-set system.theme default carapace

--- a/scripts/drupal.sh
+++ b/scripts/drupal.sh
@@ -83,9 +83,8 @@ $DRUSH_CMD -y pm-uninstall search
 $DRUSH_CMD en -y search_api
 
 # Set default theme to carapace (and download dependencies, will composer-ize later)
-$DRUSH_CMD --pm-force dl -y adaptivetheme
-$DRUSH_CMD --pm-force dl -y at_tools
-$DRUSH_CMD --pm-force dl -y layout_plugin
+cd $DRUPAL_HOME
+composer require "drupal/adaptivetheme:^2.0" "drupal/at_tools:^2.0" "drupal/layout_plugin:^1.0@alpha"
 $DRUSH_CMD en -y at_tools
 $DRUSH_CMD en -y layout_plugin
 mkdir /var/www/html/drupal/web/themes/custom

--- a/scripts/drupal.sh
+++ b/scripts/drupal.sh
@@ -82,13 +82,19 @@ $DRUSH_CMD -y en devel
 $DRUSH_CMD -y pm-uninstall search
 $DRUSH_CMD en -y search_api
 
-# Set default theme to bootstrap
-$DRUSH_CMD -y en bootstrap
-$DRUSH_CMD -y config-set system.theme default bootstrap
-## THIS IS STUPID
-# blocks are tied to themes because themes define the regions available to place blocks. gross.
-##
+# Set default theme to carapace (and download dependencies, will composer-ize later)
+$DRUSH_CMD --pm-force dl -y adaptivetheme
+$DRUSH_CMD --pm-force dl -y at_tools
+$DRUSH_CMD --pm-force dl -y layout_plugin
+$DRUSH_CMD en -y at_tools
+$DRUSH_CMD en -y layout_plugin
+mkdir /var/www/html/drupal/web/themes/custom
+git clone https://github.com/Favenzio/carapace /var/www/html/drupal/web/themes/custom/carapace
+chown -R www-data:www-data /var/www/html/drupal/web/themes/custom/carapace
+$DRUSH_CMD en -y carapace
+$DRUSH_CMD -y config-set system.theme default carapace
 
+# Islandora CLAW modules
 $DRUSH_CMD en -y islandora
 $DRUSH_CMD en -y islandora_collection
 $DRUSH_CMD en -y islandora_image


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/644

- ~~Depends on Islandora-CLAW/CLAW#667~~

# What does this Pull Request do?
Replaces installation of Bootstrap as the default theme with Carapace (and dependencies).

# How should this be tested?
Boot up the VM, localhost:8000 looks different.

# Additional Notes:
This is being installed via `drush --pm-force` and `git clone`, even though the **correct** way is to use composer. I'll integrate this with composer better in the future, but this works okay for now.

# Interested parties
@dannylamb @Favenzio @rosiel