### PR TITLE
Using LATEST API-X

### DIFF
--- a/configs/karaf/alpaca.script
+++ b/configs/karaf/alpaca.script
@@ -1,7 +1,7 @@
 config:property-set -p org.fcrepo.apix.registry.http timeout.socket.ms 1000
 
 feature:repo-add file:/home/ubuntu/Alpaca/karaf/build/resources/main/features.xml
-feature:repo-add mvn:org.fcrepo.apix/fcrepo-api-x-karaf/0.2.0/xml/features
+feature:repo-add mvn:org.fcrepo.apix/fcrepo-api-x-karaf/LATEST/xml/features
 
 feature:install fcrepo-service-camel
 


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW#666

Blocks
* https://github.com/Islandora-CLAW/Crayfish/pull/38 for Islandora-CLAW/CLAW#612 

# What does this Pull Request do?

A brief description of what the intended result of the PR will be and/or what problem it solves.

# What's new?
Pulls in SNAPSHOT builds of API-X.

# How should this be tested?

- Pull in these changes
- `vagrant up`
- `/opt/karaf/bin/client`
- `la | grep api-x`

You should see 0.3.0-SNAPSHOT for all the versions.  Mine looked like this:

```
karaf@root()> la | grep api-x
136 | Active   |  80 | 0.3.0.SNAPSHOT     | fcrepo-api-x-binding
137 | Active   |  80 | 0.3.0.SNAPSHOT     | fcrepo-api-x-jena
138 | Active   |  80 | 0.3.0.SNAPSHOT     | fcrepo-api-x-listener
139 | Active   |  80 | 0.3.0.SNAPSHOT     | fcrepo-api-x-loader
140 | Active   |  80 | 0.3.0.SNAPSHOT     | fcrepo-api-x-model
141 | Active   |  80 | 0.3.0.SNAPSHOT     | fcrepo-api-x-registry
142 | Active   |  80 | 0.3.0.SNAPSHOT     | fcrepo-api-x-routing
```

# Interested parties
@Islandora-CLAW/committers @ajs6f 