### PR TITLE
install search_api_solr and facets

### DIFF
--- a/scripts/drupal.sh
+++ b/scripts/drupal.sh
@@ -81,6 +81,9 @@ $DRUSH_CMD -y en devel
 ## https://www.drupal.org/node/2613470
 $DRUSH_CMD -y pm-uninstall search
 $DRUSH_CMD en -y search_api
+$DRUSH_CMD en -y search_api_solr
+$DRUSH_CMD en -y search_api_solr_defaults
+$DRUSH_CMD en -y facets
 
 # Set default theme to carapace (and download dependencies, will composer-ize later)
 cd $DRUPAL_HOME

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -21,6 +21,10 @@ chown -R ubuntu:ubuntu "$HOME_DIR"
 # Fix FITS log
 sed -i 's|log4j.appender.FILE.File=${catalina.home}/logs/fits-service.log|log4j.appender.FILE.File=/var/log/tomcat8/fits-service.log|g' /var/lib/tomcat8/webapps/fits/WEB-INF/classes/log4j.properties
 
+# Copy solr config
+sudo cp -R /var/www/html/drupal/web/modules/contrib/search_api_solr/solr-conf/6.x/* /var/solr/data/CLAW/conf
+service solr restart
+
 # Cycle tomcat
 cd /var/lib/tomcat8
 service tomcat8 restart


### PR DESCRIPTION
**GitHub Issue**: (link)
* https://github.com/Islandora-CLAW/CLAW/issues/698

# What does this Pull Request do?
This pull request enable the following modules:
* [Solr Search](https://www.drupal.org/project/search_api_solr) 
* search_api_solr_defaults (part of search_api_solr)
* [Facets](https://www.drupal.org/project/facets)

It copies the required search_api_solr into the solr CLAW instance 'sudo cp -R /var/www/html/drupal/web/modules/contrib/search_api_solr/solr-conf/6.x/* /var/solr/data/CLAW/conf' and restarts the solr service.  

# How should this be tested?
* This PR is dependent on https://github.com/Islandora-CLAW/drupal-project/pull/15  ***
* Once that PR gets in, checkout this branch and 'vagrant up'
* The above noted modules should be enabled in drupal

@Islandora-CLAW/committers 
