### PR TITLE
Set default solr server to point to CLAW core

### DIFF
--- a/scripts/drupal.sh
+++ b/scripts/drupal.sh
@@ -85,6 +85,9 @@ $DRUSH_CMD en -y search_api_solr
 $DRUSH_CMD en -y search_api_solr_defaults
 $DRUSH_CMD en -y facets
 
+# Set default solr server to point to CLAW core
+$DRUSH_CMD -y config-set search_api.server.default_solr_server backend_config.connector_config.core CLAW
+
 # Set default theme to carapace (and download dependencies, will composer-ize later)
 cd $DRUPAL_HOME
 composer require "drupal/adaptivetheme:^2.0" "drupal/at_tools:^2.0" "drupal/layout_plugin:^1.0@alpha"


### PR DESCRIPTION
**GitHub Issue**: (link)
https://github.com/Islandora-CLAW/CLAW/issues/707

* Other Relevant Links
    * https://drupal.stackexchange.com/questions/163993/what-is-the-command-that-replaces-drush-variable-set
    * https://www.drupal.org/docs/8/modules/search-api/advanced-site-building-tutorials/create-search-server-using-drupal-8

# What does this Pull Request do?
This PR sets the default solr server to point to the "CLAW" solr core.   

# What's new?
https://github.com/Natkeeran/claw_vagrant/blob/issue707/scripts/drupal.sh#L89

# How should this be tested?
* Get the latest claw-vagrant
* Get the PR
* Vagrant up
* Go to http://localhost:8000/admin/config/search/search-api, verify that status is enabled (green checkmark) 

# Interested parties
@seth-shaw-unlv
@Islandora-CLAW/committers
