### PR TITLE
added wildcard to Drupal's trusted_host_patterns

### DIFF
--- a/scripts/drupal.sh
+++ b/scripts/drupal.sh
@@ -47,9 +47,7 @@ rm /var/www/html/index.html
 
 ## Trusted Host Settings
 cat >> "$DRUPAL_HOME"/web/sites/default/settings.php <<EOF
-\$settings['trusted_host_patterns'] = array(
-'^localhost$',
-);
+\$settings['trusted_host_patterns'] = array('^localhost$', '.*');
 EOF
 
 # Cycle apache


### PR DESCRIPTION
Added wildcard to Drupal's trusted_host_patterns setting to allow IP or DNS-NAME or LOCALHOST.

**GitHub Issue**: (link)
https://github.com/Islandora-CLAW/CLAW/issues/710

# What does this Pull Request do?
Added wildcard to Drupal's trusted_host_patterns setting to allow IP or DNS-NAME or LOCALHOST. This helps testing your VM in a network, where others can test the site and functionality using IP of your VM or FQDN.

# What's new?
Simplified from 3 lines to 1 line and added wildcard. 

# How should this be tested?
Once in place, your VM's Drupal site will accept connections by IP address of VM or FQDN of VM or LOCALHOST (from localhost of course).

# Additional Notes:
Following should also work
`$settings['trusted_host_patterns'] = [ '.*' ];`
See more https://www.drupal.org/node/2410395

# Interested parties
@Islandora-CLAW/committers