### PR TITLE
Cycling api-x stack and loading microservices in post-install

### DIFF
--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -25,9 +25,20 @@ sed -i 's|log4j.appender.FILE.File=${catalina.home}/logs/fits-service.log|log4j.
 sudo cp -R /var/www/html/drupal/web/modules/contrib/search_api_solr/solr-conf/6.x/* /var/solr/data/CLAW/conf
 service solr restart
 
-# Cycle tomcat
-cd /var/lib/tomcat8
-service tomcat8 restart
+# Cycle some of the Java stack for Api-X
+service karaf-service stop
+service tomcat8 stop
+service activemq restart
+sleep 60
+service tomcat8 start
+sleep 60
+service karaf-service start
+sleep 60
+
+# Load microservices into Api-X
+curl -i -X POST -H "Authorization: Bearer islandora" -H "Content-Type: text/plain" -d "http://localhost:8000/houdini/convert" "http://localhost:8081/services//apix:load"
+curl -i -X POST -H "Authorization: Bearer islandora" -H "Content-Type: text/plain" -d "http://localhost:8000/houdini/identify" "http://localhost:8081/services//apix:load"
+curl -i -X POST -H "Authorization: Bearer islandora" -H "Content-Type: text/plain" -d "http://localhost:8000/hypercube/" "http://localhost:8081/services//apix:load"
 
 # Clear drupal cache
 $DRUSH_CMD cache-rebuild


### PR DESCRIPTION
**GitHub Issue**: Part of https://github.com/Islandora-CLAW/CLAW/issues/739 and https://github.com/Islandora-CLAW/CLAW/issues/738

# What does this Pull Request do?

Jiggles the cable on Api-X to get it to start up right on our single server setup.  It also loads our Crayfish microservices into Api-X so that they're available to us.

# How should this be tested?

- Pull in these changes using git
- `vagrant up`
- Ingest a Tiff (you can use Drupal or go to Fedora directly)
- Issue a HEAD request against the Tiff to get its service doc in the link headers.  For example, my tiff was located at http://localhost:8081/fcrepo/rest/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275, so I did this:
```bash
daniel@daniel-Latitude-3560:~/Code/Environments/claw_vagrant$ curl -I http://localhost:8081/fcrepo/rest/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275
HTTP/1.1 200 OK
Content-Type: image/tiff
Accept: */*
Accept-Ranges: bytes
Allow: DELETE,HEAD,GET,PUT,OPTIONS
Apix-Modality: intercept; outgoing
breadcrumbId: ID-claw-43671-1509456249000-4-42
Content-Disposition: attachment; filename=""; creation-date="Tue, 31 Oct 2017 13:35:45 GMT"; modification-date="Tue, 31 Oct 2017 13:35:45 GMT"; size=10409
ETag: "e0a384c439ac9bb813ecbc8c49dfdbc859190527"
Expires: Thu, 01 Jan 1970 00:00:00 UTC
Last-Modified: Tue, 31 Oct 2017 13:35:45 GMT
Link: <http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"
Link: <http://localhost:8081/fcrepo/rest/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275/fcr:metadata>; rel="describedby"
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://localhost:8081/discovery/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275>; rel="service"
Server: Apache-Coyote/1.1
Content-Length: 0
```
- Then issue a GET request on the service doc (it's the link header of rel=service)
```
daniel@daniel-Latitude-3560:~/Code/Environments/claw_vagrant$ curl http://localhost:8081/discovery/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275
<>      a       <http://fedora.info/definitions/v4/service#ServiceDocument> ;
        <http://fedora.info/definitions/v4/service#isServiceDocumentFor>
                <http://localhost:8081/fcrepo/rest/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275> ;
        <http://www.openarchives.org/ore/terms/describes>
                <#services> .

<#c708fb29-8877-4c07-b705-62634e2b7039>
        a       <http://fedora.info/definitions/v4/service#ServiceInstance> ;
        <http://fedora.info/definitions/v4/service#hasEndpoint>
                <http://localhost:8081/services/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275/svc:ocr> ;
        <http://fedora.info/definitions/v4/service#isFunctionOf>
                <http://localhost:8081/fcrepo/rest/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275> ;
        <http://fedora.info/definitions/v4/service#isServiceInstanceOf>
                <http://islandora.ca/CLAW#OcrService> ;
        <http://fedora.info/definitions/v4/service#serviceInstanceExposedBy>
                <http://localhost:8081/fcrepo/rest/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275> .

<#services>  <http://www.openarchives.org/ore/terms/aggregates>
                <#c708fb29-8877-4c07-b705-62634e2b7039> , <#e301fdf5-cd4a-4169-afa0-c03989cb136d> , <#b25c2e9f-26c7-40e7-b24c-697856bd8d5e> .

<#b25c2e9f-26c7-40e7-b24c-697856bd8d5e>
        a       <http://fedora.info/definitions/v4/service#ServiceInstance> ;
        <http://fedora.info/definitions/v4/service#hasEndpoint>
                <http://localhost:8081/services/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275/svc:convert> ;
        <http://fedora.info/definitions/v4/service#isFunctionOf>
                <http://localhost:8081/fcrepo/rest/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275> ;
        <http://fedora.info/definitions/v4/service#isServiceInstanceOf>
                <http://islandora.ca/CLAW#ConvertService> ;
        <http://fedora.info/definitions/v4/service#serviceInstanceExposedBy>
                <http://localhost:8081/fcrepo/rest/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275> .

<#e301fdf5-cd4a-4169-afa0-c03989cb136d>
        a       <http://fedora.info/definitions/v4/service#ServiceInstance> ;
        <http://fedora.info/definitions/v4/service#hasEndpoint>
                <http://localhost:8081/services/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275/svc:identify> ;
        <http://fedora.info/definitions/v4/service#isFunctionOf>
                <http://localhost:8081/fcrepo/rest/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275> ;
        <http://fedora.info/definitions/v4/service#isServiceInstanceOf>
                <http://islandora.ca/CLAW#IdentifyService> ;
        <http://fedora.info/definitions/v4/service#serviceInstanceExposedBy>
                <http://localhost:8081/fcrepo/rest/eb/97/cf/93/eb97cf93-f162-4981-8007-f83319848275> .
```

You should see three service instances.  One for ocr, convert, and identify.

# Interested parties
@Islandora-CLAW/committers