### PR TITLE
Remove hard coded username

### DIFF
--- a/configs/variables
+++ b/configs/variables
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 HOME_DIR=$1
+CLAW_USER=$(stat -c '%U' "$HOME_DIR")
 DOWNLOAD_DIR="$HOME_DIR/islandora/downloads"
 FEDORA_VERSION=4.7.3
 KARAF_VERSION=4.0.8

--- a/scripts/activemq.sh
+++ b/scripts/activemq.sh
@@ -15,7 +15,7 @@ fi
 cp "$DOWNLOAD_DIR/apache-activemq-$ACTIVEMQ_VERSION-bin.tar.gz" /tmp
 tar -xzf "$DOWNLOAD_DIR/apache-activemq-$ACTIVEMQ_VERSION-bin.tar.gz" -C /opt
 mv /opt/apache-activemq-$ACTIVEMQ_VERSION /opt/activemq
-chown -hR ubuntu:ubuntu /opt/activemq
+chown -hR $CLAW_USER. /opt/activemq
 
 ln -snf /opt/activemq/bin/activemq /etc/init.d/activemq
 update-rc.d activemq defaults

--- a/scripts/alpaca.sh
+++ b/scripts/alpaca.sh
@@ -11,8 +11,8 @@ fi
 cd "$HOME_DIR"
 git clone https://github.com/Islandora-CLAW/Alpaca.git
 cd Alpaca
-chown -R ubuntu:ubuntu "$HOME_DIR/Alpaca"
-sudo -u ubuntu ./gradlew install
+chown -R $CLAW_USER. "$HOME_DIR/Alpaca"
+sudo -u $CLAW_USER ./gradlew install
 
 # Chown everything over to the ubuntu user just in case
-chown -R ubuntu:ubuntu "$HOME_DIR/Alpaca"
+chown -R $CLAW_USER. "$HOME_DIR/Alpaca"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -12,7 +12,7 @@ fi
 
 #######################################################################
 # Work around for https://bugs.launchpad.net/cloud-images/+bug/1569237
-echo "ubuntu:ubuntu" | chpasswd
+echo "$CLAW_USER:$CLAW_USER" | chpasswd
 #######################################################################
 
 cd "$HOME_DIR"
@@ -44,7 +44,7 @@ apt-get -y -qq install maven
 
 # Tomcat
 apt-get -y -qq install tomcat8 tomcat8-admin
-usermod -a -G tomcat8 ubuntu
+usermod -a -G tomcat8 $CLAW_USER
 sed -i '$i<user username="islandora" password="islandora" roles="manager-gui"/>' /etc/tomcat8/tomcat-users.xml
 chown -R tomcat8:tomcat8 /var/lib/tomcat8
 chown -R tomcat8:tomcat8 /var/log/tomcat8

--- a/scripts/drupal.sh
+++ b/scripts/drupal.sh
@@ -141,4 +141,8 @@ usermod -a -G www-data $CLAW_USER
 mkdir "$HOME_DIR/auth"
 openssl genrsa -out "$HOME_DIR/auth/private.key" 2048
 openssl rsa -pubout -in "$HOME_DIR/auth/private.key" -out "$HOME_DIR/auth/public.key"
-$DRUSH_CMD config-import -y --partial --source="$HOME_DIR/islandora/configs/drupal/"
+
+cp -R "$HOME_DIR/islandora/configs/drupal" /tmp/staging-drupal
+sed -i "s|/home/ubuntu|$HOME_DIR|g" /tmp/staging-drupal/*.yml
+
+$DRUSH_CMD config-import -y --partial --source=/tmp/staging-drupal/

--- a/scripts/drupal.sh
+++ b/scripts/drupal.sh
@@ -135,7 +135,7 @@ rm *.zip
 chown -R www-data:www-data "$DRUPAL_HOME"
 chmod -R g+w "$DRUPAL_HOME"
 chmod -R 755 "$DRUPAL_HOME"/web/libraries
-usermod -a -G www-data ubuntu
+usermod -a -G www-data $CLAW_USER
 
 # Add files and config for JWT Tokens
 mkdir "$HOME_DIR/auth"

--- a/scripts/islandora-karaf-components.sh
+++ b/scripts/islandora-karaf-components.sh
@@ -10,4 +10,8 @@ fi
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 echo "Installing Karaf Features"
-$KARAF_CLIENT -f $KARAF_CONFIGS/alpaca.script
+
+cp $KARAF_CONFIGS/alpaca.script /tmp/alpaca.script
+sed -i "s|/home/ubuntu|$HOME_DIR|g" /tmp/alpaca.script
+
+$KARAF_CLIENT -f /tmp/alpaca.script

--- a/scripts/lamp-server.sh
+++ b/scripts/lamp-server.sh
@@ -2,13 +2,19 @@
 
 echo "Installing LAMP server packages"
 
+HOME_DIR=$1
+
+if [ -f "$HOME_DIR/islandora/configs/variables" ]; then
+  . "$HOME_DIR"/islandora/configs/variables
+fi
+
 PACKAGES="libwrap0 ssl-cert libterm-readkey-perl mysql-client libdbi-perl libmysqlclient20 mysql-client-core-5.7 mysql-common apache2 mysql-server mysql-server-core-5.7 tcpd libaio1 mysql-server libdbd-mysql-perl libhtml-template-perl php7.0 php7.0-dev libapache2-mod-php7.0 php7.0-mbstring"
 
 apt-get -qq install -y $PACKAGES
 
-usermod -a -G www-data ubuntu
+usermod -a -G www-data $CLAW_USER
 
-chown -R ubuntu:ubuntu islandora
+chown -R $CLAW_USER. islandora
 
 sed -i '$idate.timezone=America/Toronto' /etc/php/7.0/cli/php.ini
 

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -16,7 +16,7 @@ chown -R www-data:www-data /var/www/html
 chmod -R g+w /var/www/html
 
 # Chown the home directory for good measure
-chown -R ubuntu:ubuntu "$HOME_DIR"
+chown -R $CLAW_USER. "$HOME_DIR"
 
 # Fix FITS log
 sed -i 's|log4j.appender.FILE.File=${catalina.home}/logs/fits-service.log|log4j.appender.FILE.File=/var/log/tomcat8/fits-service.log|g' /var/lib/tomcat8/webapps/fits/WEB-INF/classes/log4j.properties

--- a/scripts/syn.sh
+++ b/scripts/syn.sh
@@ -18,5 +18,6 @@ cp build/libs/islandora-syn-*-all.jar /var/lib/tomcat8/lib/
 sed -i 's|</Context>|    <Valve className="ca.islandora.syn.valve.SynValve"/>\n</Context>|g' /var/lib/tomcat8/conf/context.xml
 cp "$HOME_DIR/islandora/configs/Syn/web.xml" /var/lib/tomcat8/webapps/fcrepo/WEB-INF/web.xml
 cp "$HOME_DIR/islandora/configs/Syn/syn-settings.xml" /var/lib/tomcat8/conf/syn-settings.xml
+sed -i "s|/home/ubuntu|$HOME_DIR|g" /var/lib/tomcat8/conf/syn-settings.xml
 
 service tomcat8 restart

--- a/scripts/syn.sh
+++ b/scripts/syn.sh
@@ -11,8 +11,8 @@ fi
 cd "$HOME_DIR"
 git clone https://github.com/Islandora-CLAW/Syn.git
 cd Syn
-chown -R ubuntu:ubuntu "$HOME_DIR/Syn"
-sudo -u ubuntu ./gradlew build
+chown -R $CLAW_USER. "$HOME_DIR/Syn"
+sudo -u $CLAW_USER ./gradlew build
 
 cp build/libs/islandora-syn-*-all.jar /var/lib/tomcat8/lib/
 sed -i 's|</Context>|    <Valve className="ca.islandora.syn.valve.SynValve"/>\n</Context>|g' /var/lib/tomcat8/conf/context.xml


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

Within Catalyst we're using a custom base box for our development environments.

The provisoning scripts in this repository assume that CLAW is to be installed
as the `ubuntu` user, which does not exist on our box.

This PR introduces the variable `CLAW_USER` through `configs/variables`,
which is automatically set to the owner of the supplied home directory.

This allows to run the CLAW Vagrant environment with a different base box,
by just changing the `home_dir` in the `Vagrantfile` instead of hunting down
all occurrences of the `ubuntu` user in scripts and config.

# What's new?

* Added `CLAW_USER` variable to `configs/variables` that is set to the owner of the supplied home directory
* Changed installation scripts to use the `CLAW_USER` variable instead of `ubuntu`
* Changed installation scripts to also replace the home directory in configs where required

# How should this be tested?

* Bring up a fresh vagrant environment with `vagrant up`
* Ensure the provisioning completes without errors

I've tested these changes against:

* The newest public `ubuntu/xenial64` base box for VirtualBox (`v20171116.0.0`)
* Our internal xenial base box for LXC (which is using the `vagrant` user instead of `ubuntu`)

# Interested parties

@Islandora-CLAW/committers